### PR TITLE
Sessions

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -40,8 +40,7 @@ socket.on('connect_timeout', err => console.error(err));
 function handleConnect() {
   console.log('connect');
   let uid = sessionStorage.getItem('__rock_in_my_boot_id__');
-  emit('message', {
-    type: 'INITIALIZE',
+  emit('initialize', {
     uid,
   });
 }

--- a/client/index.js
+++ b/client/index.js
@@ -10,45 +10,47 @@ const mountNode = document.body.querySelector('#root');
 
 socket.on('message', data => {
   let uid = sessionStorage.getItem('__rock_in_my_boot_id__');
+
   switch (data.type) {
-
-  case 'CHARACTER_SELECT_STATE':
-    ReactDOM.render(<CharacterSelect
-      uid={uid}
-      characters={data.characters}
-      onCharacterSelect={id => createCharacterSelect(emit, id)}
-      onCharacterNegate={id => createCharacterNegate(emit, id)}
-      />, mountNode);
+  case 'USER_LOGIN_SUCCESS':
+    sessionStorage.setItem('__rock_in_my_boot_id__', data.uid);
+    getCurrentState();
     break;
+  case 'CURRENT_STATE':
+    switch (data.mode) {
+    case 'CHARACTER_SELECT_STATE':
+      ReactDOM.render(<CharacterSelect
+        uid={uid}
+        characters={data.characters}
+        onCharacterSelect={id => createCharacterSelect(emit, id)}
+        onCharacterNegate={id => createCharacterNegate(emit, id)}
+        />, mountNode);
+      break;
 
-  case 'ADVENTURE_STATE':
-    ReactDOM.render(<Adventure
-      uid={uid}
-      character={data.characters.find(chr => chr.selectedBy === uid)}
-      onActionSelect={id => createActionSubmit(emit, id)}
-      />, mountNode);
+    case 'ADVENTURE_STATE':
+      ReactDOM.render(<Adventure
+        uid={uid}
+        character={data.characters.find(chr => chr.selectedBy === uid)}
+        onActionSelect={id => createActionSubmit(emit, id)}
+        />, mountNode);
+      break;
+
+    }
     break;
-
   }
 });
 
 socket.on('connect', handleConnect);
-socket.on('initialize', handleInitialize);
 socket.on('connect_error', err => console.error(err));
 socket.on('connect_timeout', err => console.error(err));
 
 function handleConnect() {
   console.log('connect');
   let uid = sessionStorage.getItem('__rock_in_my_boot_id__');
-  emit('initialize', {
+  emit('message', {
+    type: 'USER_LOGIN',
     uid,
   });
-}
-
-function handleInitialize(data) {
-  console.log('initialized with uid', data);
-  sessionStorage.setItem('__rock_in_my_boot_id__', data.uid);
-  getCurrentState();
 }
 
 function getSocketUrl() {

--- a/lib/game.js
+++ b/lib/game.js
@@ -17,7 +17,6 @@ import {
 
 const log = debug('rockin:messages');
 
-let connectedClients = {};
 let appState = {
   mode: CHARACTER_SELECT_STATE,
   characters: [
@@ -109,24 +108,11 @@ export default function initializeGame(externalEmit) {
     sendCurrentState();
   }
 
-  function handleClientInitialize(uid, action) {
-    let _uid = action.uid;
-    if (!_uid) {
-      _uid = Math.random().toString(36);
-      connectedClients[_uid] = this; // hold onto socket?
-    }
-
-    this.emit('initialize', { uid: _uid });
-  }
-
   return function handleMessage(action) {
     let { uid } = action;
 
     log('[ %s ] incoming: %o', this.id, action);
     switch (action.type) {
-      case INITIALIZE:
-        handleClientInitialize.call(this, uid, action);
-        break;
       case CURRENT_STATE:
         sendCurrentState.call(this, uid, action);
         break;

--- a/lib/game.js
+++ b/lib/game.js
@@ -2,6 +2,8 @@
 
 import debug from 'debug';
 import {
+  CURRENT_STATE,
+  INITIALIZE,
   CLIENT_CONNECTED,
   CREATE_GROUP,
   JOIN_GROUP,
@@ -15,7 +17,9 @@ import {
 
 const log = debug('rockin:messages');
 
+let connectedClients = {};
 let appState = {
+  mode: CHARACTER_SELECT_STATE,
   characters: [
     {
       id: 'mage',
@@ -44,11 +48,16 @@ let appState = {
   ]
 };
 
-export default function initializeGame(emit) {
+export default function initializeGame(externalEmit) {
 
-  function handleSendCurrentState(uid, action) {
+  function emit(action) {
+    log('outbound: %o', action);
+    externalEmit(action);
+  }
+
+  function sendCurrentState(uid, action) {
     // TODO: put type in app state; character select mode / adventure mode
-    emit(Object.assign({ type: CHARACTER_SELECT_STATE }, appState));
+    emit(Object.assign({ type: appState.mode }, appState));
   }
 
   function handleCharacterChosen(uid, action) {
@@ -73,9 +82,10 @@ export default function initializeGame(emit) {
 
     let remaining = appState.characters.filter(ch => ch.selectedBy === null && !ch.negated);
     if (remaining.length === 0) {
-      emit({ type: ADVENTURE_STATE, adventure: 'MAXIMUM' });
+      appState = Object.assign({}, appState, { mode: ADVENTURE_STATE });
+      sendCurrentState();
     } else {
-      emit(Object.assign({ type: CHARACTER_SELECT_STATE }, appState));
+      sendCurrentState();
     }
   }
 
@@ -94,19 +104,33 @@ export default function initializeGame(emit) {
 
     let remaining = appState.characters.filter(ch => ch.selectedBy === null && !ch.negated);
     if (remaining.length === 0) {
-      emit({ type: ADVENTURE_STATE, adventure: 'MAXIMUM' });
+      appState = Object.assign({}, appState, { mode: ADVENTURE_STATE });
+      sendCurrentState();
     } else {
-      emit(Object.assign({ type: CHARACTER_SELECT_STATE }, appState));
+      sendCurrentState();
     }
   }
 
-  return function handleMessage(action) {
-    let { id: uid } = this;
+  function handleClientInitialize(uid, action) {
+    let _uid = action.uid;
+    if (!_uid) {
+      _uid = Math.random().toString(36);
+      connectedClients[_uid] = this; // hold onto socket?
+    }
 
-    log('[ %s ] action: %o', uid, action);
+    this.emit('initialize', { uid: _uid });
+  }
+
+  return function handleMessage(action) {
+    let { uid } = action;
+
+    log('[ %s ] incoming: %o', this.id, action);
     switch (action.type) {
-      case 'CURRENT_STATE':
-        handleSendCurrentState.call(this, uid, action);
+      case INITIALIZE:
+        handleClientInitialize.call(this, uid, action);
+        break;
+      case CURRENT_STATE:
+        sendCurrentState.call(this, uid, action);
         break;
       case CHARACTER_CHOSEN:
         handleCharacterChosen.call(this, uid, action);

--- a/lib/game.js
+++ b/lib/game.js
@@ -3,7 +3,6 @@
 import debug from 'debug';
 import {
   CURRENT_STATE,
-  INITIALIZE,
   CLIENT_CONNECTED,
   CREATE_GROUP,
   JOIN_GROUP,
@@ -56,7 +55,7 @@ export default function initializeGame(externalEmit) {
 
   function sendCurrentState(uid, action) {
     // TODO: put type in app state; character select mode / adventure mode
-    emit(Object.assign({ type: appState.mode }, appState));
+    emit(Object.assign({ type: CURRENT_STATE }, appState));
   }
 
   function handleCharacterChosen(uid, action) {
@@ -111,16 +110,16 @@ export default function initializeGame(externalEmit) {
   return function handleMessage(action) {
     let { uid } = action;
 
-    log('[ %s ] incoming: %o', this.id, action);
+    log('[ %s ] incoming: %o', uid, action);
     switch (action.type) {
       case CURRENT_STATE:
-        sendCurrentState.call(this, uid, action);
+        sendCurrentState(uid, action);
         break;
       case CHARACTER_CHOSEN:
-        handleCharacterChosen.call(this, uid, action);
+        handleCharacterChosen(uid, action);
         break;
       case CHARACTER_NEGATE:
-        handleCharacterNegate.call(this, uid, action);
+        handleCharacterNegate(uid, action);
         break;
       case SUBMIT_ACTION:
         break;

--- a/lib/game.js
+++ b/lib/game.js
@@ -83,10 +83,9 @@ export default function initializeGame(externalEmit) {
     let remaining = appState.characters.filter(ch => ch.selectedBy === null && !ch.negated);
     if (remaining.length === 0) {
       appState = Object.assign({}, appState, { mode: ADVENTURE_STATE });
-      sendCurrentState();
-    } else {
-      sendCurrentState();
     }
+
+    sendCurrentState();
   }
 
   function handleCharacterNegate(uid, action) {
@@ -105,10 +104,9 @@ export default function initializeGame(externalEmit) {
     let remaining = appState.characters.filter(ch => ch.selectedBy === null && !ch.negated);
     if (remaining.length === 0) {
       appState = Object.assign({}, appState, { mode: ADVENTURE_STATE });
-      sendCurrentState();
-    } else {
-      sendCurrentState();
     }
+
+    sendCurrentState();
   }
 
   function handleClientInitialize(uid, action) {

--- a/lib/gameActionTypes.js
+++ b/lib/gameActionTypes.js
@@ -1,6 +1,8 @@
 'use strict';
 
 // client => server actions
+export const INITIALIZE = 'INITIALIZE';
+export const CURRENT_STATE = 'CURRENT_STATE';
 export const CREATE_GROUP = 'CREATE_GROUP';
 export const JOIN_GROUP = 'JOIN_GROUP';
 export const CHARACTER_CHOSEN = 'CHARACTER_CHOSEN';

--- a/server/server.js
+++ b/server/server.js
@@ -16,13 +16,22 @@ const io = IO(config.WSS_PORT);
 // create one per websocket room?
 const roomSocketHandler = initializeGame(action => io.emit('message', action));
 
+function handleClientInitialize(action) {
+  let uid = action.uid;
+  if (!uid) {
+    uid = Math.random().toString(36);
+  }
+
+  this.emit('initialize', { uid });
+}
+
 io.on('connection', socket => {
   let count = Object.keys(io.sockets.sockets).length;
   wssLog('client connected [ %s ] ( %s )', socket.id, count);
 
   // figure out better way to do this?
   // roomSocketHandler.call(socket, ({ type: 'CURRENT_STATE' }));
-
+  socket.on('initialize', handleClientInitialize);
   socket.on('message', roomSocketHandler);
   socket.on('disconnect', () => {
     let count = Object.keys(io.sockets.sockets).length;

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,7 @@ io.on('connection', socket => {
   wssLog('client connected [ %s ] ( %s )', socket.id, count);
 
   // figure out better way to do this?
-  roomSocketHandler.call(socket, ({ type: 'CURRENT_STATE' }));
+  // roomSocketHandler.call(socket, ({ type: 'CURRENT_STATE' }));
 
   socket.on('message', roomSocketHandler);
   socket.on('disconnect', () => {

--- a/server/server.js
+++ b/server/server.js
@@ -22,17 +22,27 @@ function handleClientInitialize(action) {
     uid = Math.random().toString(36);
   }
 
-  this.emit('initialize', { uid });
+  return uid;
 }
 
 io.on('connection', socket => {
   let count = Object.keys(io.sockets.sockets).length;
   wssLog('client connected [ %s ] ( %s )', socket.id, count);
 
-  // figure out better way to do this?
-  // roomSocketHandler.call(socket, ({ type: 'CURRENT_STATE' }));
-  socket.on('initialize', handleClientInitialize);
-  socket.on('message', roomSocketHandler);
+  socket.on('message', action => {
+    if (action.type === 'USER_LOGIN') {
+      let uid = handleClientInitialize(action);
+
+      socket.emit('message', {
+        type: 'USER_LOGIN_SUCCESS',
+        uid
+      });
+      return;
+    }
+
+    roomSocketHandler(action);
+  });
+
   socket.on('disconnect', () => {
     let count = Object.keys(io.sockets.sockets).length;
     wssLog('client disconnect [ %s ] ( %s )', socket.id, count);


### PR DESCRIPTION
I figured we should have some sort of handshake logic to make sure that if a client disconnects and then reconnects, that they are still able to play in the game.

Flow: 
1. Client connects
2. Client sends sessionID to server via special event name `'initialize'`
3. Server handles sessionID:
   1. If sessionID sent, echo back to client via special event name `'initialize'`
   2. If no sessionID sent, server generates one and sends back to client via special event name `'initialize'`
4. Client stores new sessionID in `sessionStorage`
5. Client requests current game state

I also added this sessionID to every message from the client to the server. I figured that this way, we don't have to really keep the sessionID tied to a socket, which further decouples us from socket.io specific communication. 
