### PR TITLE
middleware for game mode, still doesn't fix inconsistent state.

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -18,14 +18,18 @@ import {
   createGenerateRooms,
 } from './actions/rooms';
 
+import {
+  gameModeMachine,
+} from './redux-middlewares/game-mode-machine';
+
 const log = debug('rockin:messages');
 
 export default function initializeGame(externalEmit) {
-  let store = createStore(combinedReducers, applyMiddleware(reduxThunk));
+  let store = createStore(combinedReducers, applyMiddleware(reduxThunk, gameModeMachine));
 
   store.subscribe(() => {
     emit(mapToClientState(store.getState()));
-    updateLifecycle(store.dispatch, store.getState);
+    //updateLifecycle(store.dispatch, store.getState);
   });
 
   // This is a huge hack right now, because we don't have a consistent
@@ -34,17 +38,22 @@ export default function initializeGame(externalEmit) {
   // dispatch could cause a state change that results in an "intermediate
   // mode", such as ENTER_ROOM_MODE but we're out of rooms and the
   // END_GAME_MODE hasn't been set yet.
-  const emit = (function () {
-    const msLimit = 100;
-    let id = null;
-    return function emit(action) {
-      if (id) clearTimeout(id);
-      id = setTimeout(() => {
-        log('outbound: %o', action);
-        externalEmit(action);
-      }, msLimit);
-    }
-  }());
+  //const emit = (function () {
+  //  const msLimit = 100;
+  //  let id = null;
+  //  return function emit(action) {
+  //    if (id) clearTimeout(id);
+  //    id = setTimeout(() => {
+  //      log('outbound: %o', action);
+  //      externalEmit(action);
+  //    }, msLimit);
+  //  }
+  //}());
+
+  function emit (action) {
+    log('outbound: %o', action);
+    externalEmit(action);
+  }
 
   function mapToClientState(state) {
     const room = state.roomGen.room

--- a/lib/redux-middlewares/game-mode-machine.js
+++ b/lib/redux-middlewares/game-mode-machine.js
@@ -1,0 +1,74 @@
+import debug from 'debug';
+
+import {
+  MODE_CHANGE,
+  CHARACTER_SELECT_MODE,
+  ENTER_ROOM_MODE,
+  END_GAME_MODE,
+  SUBMIT_ACTION,
+} from '../gameActionTypes';
+
+import {
+  createGenerateRooms,
+} from '../actions/rooms';
+
+
+const log = debug('rockin:game-mode-machine');
+
+export function gameModeMachine ({ dispatch, getState }) {
+  return (next) => {
+    return (action) => {
+
+      log('next(action)', action && action.type);
+      const returnVal = next(action);
+
+      const state = getState();
+      // ...then figure out where we should be lifecycle-wise
+
+      // TODO: this should be in the characters reducer.
+      const everyCharacterSelectedOrNegated = state
+        .characters
+        .every(c => c.selectedBy !== null || c.negated);
+
+      if (
+        state.mode === CHARACTER_SELECT_MODE
+        && everyCharacterSelectedOrNegated
+        && !state.roomGen.room
+      ) {
+        log('generating rooms');
+        // generate first room, change mode
+        dispatch(createGenerateRooms());
+        return;
+      }
+
+      if (
+        state.mode === CHARACTER_SELECT_MODE
+        && everyCharacterSelectedOrNegated
+        && state.roomGen.room
+      ) {
+        log('switching to first room');
+        // only the lifecycle thunk can cause mode changes?
+        dispatch({
+          type: MODE_CHANGE,
+          mode: ENTER_ROOM_MODE,
+        });
+        return;
+      }
+
+      if (
+        state.mode === ENTER_ROOM_MODE
+        && !state.roomGen.room
+      ) {
+        log('ending game');
+        dispatch({
+          type: MODE_CHANGE,
+          mode: END_GAME_MODE,
+        });
+
+        return;
+      }
+
+      return returnVal;
+    }
+  }
+}


### PR DESCRIPTION
experiment to see if middleware helps... it doesn't, still get multiple subscribe callbacks. might have to implement our own global reducer to manage end game / major state transitions atomically.
